### PR TITLE
Use a version constraint for Unit Converter to stop composer from com…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.1",
-        "jordanbrauer/unit-converter": "dev-master"
+        "jordanbrauer/unit-converter": "^0.8.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0",


### PR DESCRIPTION
…plaining...

And ensuring a major version doesn't get picked up and break things